### PR TITLE
[CodeGenerator] ساده سازی MainWindow با استفاده از Frame

### DIFF
--- a/src/infra/CodeGenerator/MainWindow.xaml
+++ b/src/infra/CodeGenerator/MainWindow.xaml
@@ -1,34 +1,10 @@
-﻿<Window
+<Window
     x:Class="CodeGenerator.MainWindow"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     Title="Code Generator"
     Width="900"
     Height="600">
-    <Grid>
-        <Grid.RowDefinitions>
-            <!--  Top menu  -->
-            <RowDefinition Height="Auto" />
-            <!--  Main content  -->
-            <RowDefinition Height="*" />
-            <!--  Status bar  -->
-            <RowDefinition Height="Auto" />
-        </Grid.RowDefinitions>
-
-        <!--  Navigation Menu  -->
-        <Menu Grid.Row="0">
-            <MenuItem Command="{Binding NavigateDtosCommand}" Header="DTOs" />
-            <MenuItem Command="{Binding NavigateFunctionalitiesCommand}" Header="Functionalities" />
-            <!--  add more menu items as needed  -->
-        </Menu>
-
-        <!--  Content Frame / MVVM Shell  -->
-        <ContentControl Grid.Row="1" Content="{Binding CurrentPageViewModel}" />
-
-        <!--  Status Bar  -->
-        <StatusBar Grid.Row="2">
-            <TextBlock Text="{Binding StatusMessage}" />
-        </StatusBar>
-    </Grid>
+    <Frame x:Name="MainFrame"
+           NavigationUIVisibility="Hidden" />
 </Window>
-


### PR DESCRIPTION
## Summary
- تغییر ساختار `MainWindow` در پروژه CodeGenerator و حذف منو و گرید
- استفاده از یک `Frame` برای نمایش صفحات در کل پنجره

## Testing
- `dotnet build MES20.slnx -clp:Summary` *(failed: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_685d4608ac24832680a41a773db608e8