### PR TITLE
Implement exit confirmation in MainWindow

### DIFF
--- a/src/infra/CodeGenerator/MainWindow.xaml
+++ b/src/infra/CodeGenerator/MainWindow.xaml
@@ -18,7 +18,7 @@
                     <MenuItem Header="Blazor _Pages..." />
                 </MenuItem>
                 <Separator />
-                <MenuItem Header="E_xit…" />
+                <MenuItem Header="E_xit…" Command="{Binding ExitCommand}" />
             </MenuItem>
             <MenuItem Header="_Tools">
                 <MenuItem Header="_Settings..." />

--- a/src/infra/CodeGenerator/MainWindow.xaml.cs
+++ b/src/infra/CodeGenerator/MainWindow.xaml.cs
@@ -1,16 +1,62 @@
-﻿using System.Windows;
+using System.ComponentModel;
+using System.Windows;
+using CodeGenerator.Designer.UI.Common;
 using CodeGenerator.UI;
 
 using Microsoft.WindowsAPICodePack.Dialogs;
 
 namespace CodeGenerator;
+
 /// <summary>
 /// Interaction logic for MainWindow.xaml
 /// </summary>
 public partial class MainWindow : Window
 {
+    private bool _allowClose;
+    public RelayCommand ExitCommand { get; }
+
     public MainWindow()
     {
         InitializeComponent();
+        DataContext = this;
+        ExitCommand = new RelayCommand(_ => ExitApplication());
+    }
+
+    partial void OnExitConfirmed();
+
+    private bool ConfirmExit()
+    {
+        using var dialog = TaskDialogExtension.Create()
+            .WithInstructionText("Are you sure you want to exit?")
+            .WithCaption("Confirm Exit")
+            .WithButtons(TaskDialogStandardButtons.Yes | TaskDialogStandardButtons.No)
+            .WithIcon(TaskDialogStandardIcon.Warning);
+        if (dialog.Show() is TaskDialogResult.Yes)
+        {
+            OnExitConfirmed();
+            return true;
+        }
+        return false;
+    }
+
+    private void ExitApplication()
+    {
+        if (ConfirmExit())
+        {
+            _allowClose = true;
+            Application.Current.Shutdown();
+        }
+    }
+
+    protected override void OnClosing(CancelEventArgs e)
+    {
+        if (!_allowClose)
+        {
+            e.Cancel = !ConfirmExit();
+            if (!e.Cancel)
+                _allowClose = true;
+        }
+        base.OnClosing(e);
     }
 }
+


### PR DESCRIPTION
## Summary
- افزوده شدن متد تائید خروج برای جلوگیری از بسته شدن ناخواسته برنامه
- استفاده از این متد در منوی Exit و رویداد Closing پنجره اصلی

## Testing
- `dotnet build MES20.slnx` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_e_686906bfddf083269eeeddb683d319cc