### PR TITLE
[CodeGenerator] fix static viewmodel loading

### DIFF
--- a/src/infra/CodeGenerator/Designer/UI/Pages/DtoManagementPage.xaml.cs
+++ b/src/infra/CodeGenerator/Designer/UI/Pages/DtoManagementPage.xaml.cs
@@ -1,4 +1,5 @@
-﻿using System.Windows;
+﻿using System.Collections.ObjectModel;
+using System.Windows;
 using System.Windows.Controls;
 
 using CodeGenerator.Application.Services;
@@ -22,11 +23,11 @@ public partial class DtoManagementPage : UserControl
     public DtoManagementPage(IModuleService moduleService)
     {
         this._moduleService = moduleService;
-        this.SetStaticViewModel();
 
         this.InitializeComponent();
 
         this.DataContextChanged += this.DtoManagementPage_DataContextChanged;
+        this.Loaded += this.DtoManagementPage_Loaded;
     }
 
     public DtoManagementPageStaticViewModel StaticViewModel
@@ -50,14 +51,20 @@ public partial class DtoManagementPage : UserControl
         this.DataContext = model;
     }
 
-    private async void SetStaticViewModel()
+    private async Task LoadStaticViewModelAsync()
     {
         var modules = await this._moduleService.GetAll().ParseValue().ToViewModel();
         this.StaticViewModel = new(modules);
+    }
+
+    private async void DtoManagementPage_Loaded(object sender, RoutedEventArgs e)
+    {
+        this.Loaded -= this.DtoManagementPage_Loaded;
+        await this.LoadStaticViewModelAsync();
     }
 }
 
 public sealed class DtoManagementPageStaticViewModel(IEnumerable<ModuleViewModel> modules)
 {
-    public IEnumerable<ModuleViewModel> Modules { get; set; } = modules;
+    public ObservableCollection<ModuleViewModel> Modules { get; } = new(modules);
 }


### PR DESCRIPTION
## Summary
- load modules after page loading
- use `ObservableCollection` for module list

## Testing
- `dotnet build src/infra/CodeGenerator/CodeGenerator.csproj -v:q` *(fails: NETSDK1045 Targeting .NET 10.0 not supported)*

------
https://chatgpt.com/codex/tasks/task_e_687532fdfa7483269d92d9cf2bed9ba6