### PR TITLE
Implement GenerateCodes with Roslyn engine

### DIFF
--- a/src/infra/CodeGenerator/App.xaml.cs
+++ b/src/infra/CodeGenerator/App.xaml.cs
@@ -2,6 +2,9 @@
 
 using CodeGenerator.Application.Services;
 using CodeGenerator.Designer.UI.Pages;
+using Library.CodeGenLib;
+using Library.CodeGenLib.Back;
+using Library.CodeGenLib.CodeGenerators;
 
 using Library.Validations;
 
@@ -96,6 +99,7 @@ public partial class App : System.Windows.Application
                             .AddTransient<DtoManagementPage>();
 
                         _ = services.AddTransient<IDtoService, DtoService>();
+                        _ = services.AddTransient<ICodeGeneratorEngine<INamespace>, RoslynCodeGenerator>();
 
                         _ = services.AddTransient(x => new SqlConnection(Settings.Default.ConnectionString));
 

--- a/src/infra/CodeGenerator/Application/Services/DtoService.cs
+++ b/src/infra/CodeGenerator/Application/Services/DtoService.cs
@@ -1,20 +1,62 @@
 namespace CodeGenerator.Application.Services;
 
 using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 
 using CodeGenerator.Application.Domain;
 
+using Library.CodeGenLib;
+using Library.CodeGenLib.Back;
 using Library.CodeGenLib.Models;
 using Library.Resulting;
 using Microsoft.Data.SqlClient;
 
-internal sealed partial class DtoService(SqlConnection connection) : IDtoService
+internal sealed partial class DtoService(SqlConnection connection, ICodeGeneratorEngine<INamespace> codeGenerator) : IDtoService
 {
     private readonly SqlConnection _connection = connection;
+    private readonly ICodeGeneratorEngine<INamespace> _codeGenerator = codeGenerator;
 
     [return: NotNull]
-    public IResult<Codes> GenerateCodes(Dto dto, CancellationToken ct = default) =>
-        Result.Fail<Codes>(new NotImplementedException());
+    public IResult<Codes> GenerateCodes(Dto dto, CancellationToken ct = default)
+    {
+        if (dto is null)
+        {
+            return Result.Fail<Codes>(new ArgumentNullException(nameof(dto)));
+        }
+
+        var nameSpace = INamespace.New(dto.Namespace);
+        var classType = IClass.New(dto.Name) with { InheritanceModifier = InheritanceModifier.Partial };
+
+        if (!dto.BaseType.IsNullOrEmpty())
+        {
+            classType.AddBaseType(TypePath.Parse(dto.BaseType!));
+        }
+
+        foreach (var prop in dto.Properties)
+        {
+            var type = TypePath.Parse(prop.TypeFullName ?? "object");
+            if (prop.IsList == true)
+            {
+                type = TypePath.ParseEnumerable(type);
+            }
+
+            if (prop.IsNullable == true)
+            {
+                type = type.WithNullable(true);
+            }
+
+            var setter = prop.HasSetter != false ? new PropertyAccessor() : null;
+            var getter = prop.HasGetter != false ? new PropertyAccessor() : null;
+
+            var property = new CodeGenProperty(prop.Name, type, setter: setter, getter: getter);
+            classType.AddProperty(property);
+        }
+
+        nameSpace.AddType(classType);
+
+        var codeResult = this._codeGenerator.Generate(nameSpace, dto.Name, Languages.CSharp, true);
+        return Result.From<Codes>(codeResult, new Codes(codeResult.Value));
+    }
 
     [return: NotNull]
     public Task<IResult<IEnumerable<Dto>>> GetAll(CancellationToken ct = default) =>


### PR DESCRIPTION
## Summary
- inject `ICodeGeneratorEngine<INamespace>` backed by `RoslynCodeGenerator`
- use Roslyn engine in `DtoService.GenerateCodes`

## Testing
- `dotnet build MES20.slnx -warnaserror` *(fails: unrecognized .slnx)*

------
https://chatgpt.com/codex/tasks/task_e_688127f79e4483268f708f54ae3508f0