### PR TITLE
Add codes viewer control

### DIFF
--- a/src/infra/CodeGenerator/Designer/UI/Controls/CodesViewerControl.xaml
+++ b/src/infra/CodeGenerator/Designer/UI/Controls/CodesViewerControl.xaml
@@ -1,0 +1,7 @@
+<UserControl
+    x:Class="CodeGenerator.Designer.UI.Controls.CodesViewerControl"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="clr-namespace:CodeGenerator.Designer.UI.Controls">
+    <TabControl x:Name="Tabs" />
+</UserControl>

--- a/src/infra/CodeGenerator/Designer/UI/Controls/CodesViewerControl.xaml.cs
+++ b/src/infra/CodeGenerator/Designer/UI/Controls/CodesViewerControl.xaml.cs
@@ -1,0 +1,61 @@
+using System.Windows;
+using System.Windows.Controls;
+
+using Library.CodeGenLib.Models;
+
+namespace CodeGenerator.Designer.UI.Controls;
+
+public partial class CodesViewerControl : UserControl
+{
+    public CodesViewerControl() => this.InitializeComponent();
+
+    public Codes Codes
+    {
+        get => (Codes)this.GetValue(CodesProperty);
+        set => this.SetValue(CodesProperty, value);
+    }
+
+    public static readonly DependencyProperty CodesProperty =
+        DependencyProperty.Register(
+            nameof(Codes),
+            typeof(Codes),
+            typeof(CodesViewerControl),
+            new PropertyMetadata(Codes.Empty, OnCodesPropertyChanged));
+
+    private static void OnCodesPropertyChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+    {
+        if (d is CodesViewerControl control && e.NewValue is Codes codes)
+        {
+            control.UpdateTabs(codes);
+        }
+    }
+
+    private void UpdateTabs(Codes codes)
+    {
+        this.Tabs.Items.Clear();
+        foreach (var code in codes)
+        {
+            if (code is null)
+            {
+                continue;
+            }
+
+            var box = new TextBox
+            {
+                Text = code.Statement,
+                AcceptsReturn = true,
+                VerticalScrollBarVisibility = ScrollBarVisibility.Auto,
+                IsReadOnly = true
+            };
+            var tab = new TabItem
+            {
+                Header = code.Name,
+                Content = box
+            };
+            this.Tabs.Items.Add(tab);
+        }
+        this.OnCodesChanged(codes);
+    }
+
+    partial void OnCodesChanged(Codes codes);
+}


### PR DESCRIPTION
## Summary
- rename to `CodesViewerControl`
- dynamically generate tabs for `Codes` and show statements

## Testing
- `dotnet build MES20.slnx -v:m` *(fails: unrecognized element `Solution`)*

------
https://chatgpt.com/codex/tasks/task_e_68813d81a2988326a978f3077a80c497