### PR TITLE
[CodeGenerator] تبدیل نوع داده SQL به .NET در تولید کد

### DIFF
--- a/src/bcl/DataLib/SqlServer/SqlType.cs
+++ b/src/bcl/DataLib/SqlServer/SqlType.cs
@@ -1,3 +1,4 @@
+using Library.Coding;
 ﻿namespace DataLib.SqlServer;
 
 public static class SqlTypeUtils
@@ -30,5 +31,18 @@ public static class SqlTypeUtils
         yield return ("varchar", typeof(string)); // Map "varchar" or "nvarchar" to string.
         yield return ("nvarchar", typeof(string)); // Map "varchar" or "nvarchar" to string.
         yield return ("bit", typeof(bool)); // Map "bit" to bool.
+    }
+
+    public static string ToNetTypeName(string sqlTypeName)
+    {
+        foreach (var (name, type) in GetSqlTypes())
+        {
+            if (string.Equals(name, sqlTypeName, StringComparison.OrdinalIgnoreCase))
+            {
+                return TypePath.AsKeyword(type.FullName ?? type.Name);
+            }
+        }
+
+        return sqlTypeName;
     }
 }

--- a/src/infra/CodeGenerator/Designer/UI/ViewModels/Extensions.cs
+++ b/src/infra/CodeGenerator/Designer/UI/ViewModels/Extensions.cs
@@ -1,3 +1,4 @@
+using DataLib.SqlServer;
 ﻿namespace CodeGenerator.Designer.UI.ViewModels;
 
 public static class Extensions
@@ -16,7 +17,22 @@ public static class Extensions
             IsViewModel = @this.IsViewModel,
             DbObjectId = @this.ObjectId.ToString(),
             ModuleId = @this.Module?.Id,
-            Properties = [.. @this.Properties],
+            Properties = [.. @this.Properties.Select(p => new Property
+            {
+                Comment = p.Comment,
+                DbObjectId = p.DbObjectId,
+                DtoId = p.DtoId,
+                Guid = p.Guid,
+                HasGetter = p.HasGetter,
+                HasSetter = p.HasSetter,
+                Id = p.Id,
+                IsList = p.IsList,
+                IsNullable = p.IsNullable,
+                Name = p.Name,
+                ParentEntityId = p.ParentEntityId,
+                PropertyType = p.PropertyType,
+                TypeFullName = SqlTypeUtils.ToNetTypeName(p.TypeFullName ?? string.Empty),
+            })],
         };
     }
 }


### PR DESCRIPTION
## Summary
- افزودن متد `ToNetTypeName` برای تبدیل SQL Type به نام معادل در .NET
- تبدیل نوع داده خصوصیات در `DtoViewModel.ToEntity` قبل از فراخوانی سرویس تولید کد

## Testing
- اجرای `dotnet build MES20.slnx -c Release` *(با خطای پشتیبانی نشدن قالب slnx)*

------
https://chatgpt.com/codex/tasks/task_e_688218395c608326b222f1f006de5161