### PR TITLE
[CodeGenerator] اصلاح وضعیت CodesViewer

### DIFF
--- a/src/infra/CodeGenerator/Designer/UI/Pages/DtoManagementPage.xaml
+++ b/src/infra/CodeGenerator/Designer/UI/Pages/DtoManagementPage.xaml
@@ -178,7 +178,9 @@
             </Grid>
         </bases:BasePage.EntityDesignerContent>
         <bases:BasePage.SourceCodeContent>
-            <controls:CodesViewerControl x:Name="CodesViewer" />
+            <controls:CodesViewerControl x:Name="CodesViewer"
+                                         HorizontalAlignment="Stretch"
+                                         VerticalAlignment="Stretch" />
         </bases:BasePage.SourceCodeContent>
     </bases:BasePage>
 </UserControl>


### PR DESCRIPTION
## خلاصه تغییرات
- تنظیم کنترل `CodesViewerControl` برای پر کردن کامل فضای تب کدها

## تست‌ها
- اجرای `dotnet build` روی پروژه ناموفق بود چون SDK از دات‌نت 10 پشتیبانی نمی‌کند

------
https://chatgpt.com/codex/tasks/task_e_6883e528b08c832680d670e572d81aac