### PR TITLE
Implement CatchResultAsync for DtoService

### DIFF
--- a/src/infra/CodeGenerator/Application/Services/DtoService.cs
+++ b/src/infra/CodeGenerator/Application/Services/DtoService.cs
@@ -1,4 +1,5 @@
 ﻿using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 
 using Library.CodeGenLib;
 using Library.CodeGenLib.Back;
@@ -9,6 +10,12 @@ using Library.Validations;
 
 using Microsoft.Data.SqlClient;
 
+using CodeGenerator.Application.Domain;
+
+using Dapper;
+using DataLib.Extensions;
+
+
 namespace CodeGenerator.Application.Services;
 
 internal sealed partial class DtoService(SqlConnection connection, ICodeGeneratorEngine<INamespace> codeGenerator) : IDtoService
@@ -18,7 +25,7 @@ internal sealed partial class DtoService(SqlConnection connection, ICodeGenerato
 
     [return: NotNull]
     public Task<IResult> Delete(long id, CancellationToken ct = default) =>
-        Task.FromResult<IResult>(Result.Fail(new NotImplementedException()));
+        CatchResultAsync(() => this._connection.ExecuteAsync("DELETE FROM [infra].[Dto] WHERE Id = @Id", new { Id = id }));
 
     [return: NotNull]
     public IResult<Codes> GenerateCodes(Dto dto, CancellationToken ct = default) => CatchResult(() =>
@@ -63,17 +70,196 @@ internal sealed partial class DtoService(SqlConnection connection, ICodeGenerato
 
     [return: NotNull]
     public Task<IResult<IEnumerable<Dto>>> GetAll(CancellationToken ct = default) =>
-        Task.FromResult<IResult<IEnumerable<Dto>>>(Result.Fail<IEnumerable<Dto>>(new NotImplementedException()));
+        CatchResultAsync(async () =>
+        {
+            var dtos = (await this._connection.QueryAsync<Dto>("SELECT * FROM [infra].[Dto]")).ToList();
+            foreach (var dto in dtos)
+            {
+                var props = await this._connection.QueryAsync<Property>(
+                    "SELECT * FROM [infra].[Property] WHERE DtoId = @Id",
+                    new { Id = dto.Id });
+                dto.Properties = [.. props];
+            }
+
+            return dtos.AsEnumerable();
+        });
 
     [return: NotNull]
     public Task<IResult<Dto?>> GetById(long id, CancellationToken ct = default) =>
-        Task.FromResult<IResult<Dto?>>(Result.Fail<Dto?>(new NotImplementedException()));
+        CatchResultAsync(async () =>
+        {
+            var dto = await this._connection.QueryFirstOrDefaultAsync<Dto>(
+                "SELECT * FROM [infra].[Dto] WHERE Id = @Id",
+                new { Id = id });
+
+            if (dto is not null)
+            {
+                var props = await this._connection.QueryAsync<Property>(
+                    "SELECT * FROM [infra].[Property] WHERE DtoId = @Id",
+                    new { Id = dto.Id });
+                dto.Properties = [.. props];
+            }
+
+            return dto;
+        });
 
     [return: NotNull]
     public Task<IResult<long>> Insert(Dto dto, CancellationToken ct = default) =>
-        Task.FromResult<IResult<long>>(Result.Fail<long>(new NotImplementedException()));
+        CatchResultAsync(async () =>
+        {
+            const string dtoSql = @"INSERT INTO [infra].[Dto]
+    (Name, NameSpace, ModuleId, DbObjectId, Guid, Comment, IsParamsDto, IsResultDto, IsViewModel, IsList, BaseType)
+    VALUES (@Name, @NameSpace, @ModuleId, @DbObjectId, @Guid, @Comment, @IsParamsDto, @IsResultDto, @IsViewModel, @IsList, @BaseType);
+    SELECT CAST(SCOPE_IDENTITY() AS bigint);";
+
+            const string propSql = @"INSERT INTO [infra].[Property]
+    (ParentEntityId, PropertyType, TypeFullName, Name, HasSetter, HasGetter, IsList, IsNullable, Comment, DbObjectId, Guid, DtoId)
+    VALUES (@ParentEntityId, @PropertyType, @TypeFullName, @Name, @HasSetter, @HasGetter, @IsList, @IsNullable, @Comment, @DbObjectId, @Guid, @DtoId);";
+
+            var wasClosed = this._connection.State != System.Data.ConnectionState.Open;
+            if (wasClosed)
+            {
+                await this._connection.OpenAsync(ct);
+            }
+
+            using var trans = this._connection.BeginTransaction();
+            try
+            {
+                var dtoId = await this._connection.ExecuteScalarAsync<long>(dtoSql, new
+                {
+                    dto.Name,
+                    NameSpace = dto.Namespace,
+                    dto.ModuleId,
+                    dto.DbObjectId,
+                    dto.Guid,
+                    dto.Comment,
+                    dto.IsParamsDto,
+                    dto.IsResultDto,
+                    dto.IsViewModel,
+                    dto.IsList,
+                    dto.BaseType
+                }, trans);
+
+                foreach (var prop in dto.Properties)
+                {
+                    await this._connection.ExecuteAsync(propSql, new
+                    {
+                        ParentEntityId = dtoId,
+                        prop.PropertyType,
+                        prop.TypeFullName,
+                        prop.Name,
+                        prop.HasSetter,
+                        prop.HasGetter,
+                        prop.IsList,
+                        prop.IsNullable,
+                        prop.Comment,
+                        prop.DbObjectId,
+                        prop.Guid,
+                        DtoId = dtoId
+                    }, trans);
+                }
+
+                trans.Commit();
+                if (wasClosed)
+                {
+                    await this._connection.CloseAsync();
+                }
+                return dtoId;
+            }
+            catch
+            {
+                trans.Rollback();
+                if (wasClosed)
+                {
+                    await this._connection.CloseAsync();
+                }
+                throw;
+            }
+        });
 
     [return: NotNull]
     public Task<IResult> Update(long id, Dto dto, CancellationToken ct = default) =>
-        Task.FromResult<IResult>(Result.Fail(new NotImplementedException()));
+        CatchResultAsync(async () =>
+        {
+            const string dtoSql = @"UPDATE [infra].[Dto] SET
+    Name = @Name,
+    NameSpace = @NameSpace,
+    ModuleId = @ModuleId,
+    DbObjectId = @DbObjectId,
+    Guid = @Guid,
+    Comment = @Comment,
+    IsParamsDto = @IsParamsDto,
+    IsResultDto = @IsResultDto,
+    IsViewModel = @IsViewModel,
+    IsList = @IsList,
+    BaseType = @BaseType
+WHERE Id = @Id";
+
+            const string deletePropSql = "DELETE FROM [infra].[Property] WHERE DtoId = @Id";
+            const string propSql = @"INSERT INTO [infra].[Property]
+    (ParentEntityId, PropertyType, TypeFullName, Name, HasSetter, HasGetter, IsList, IsNullable, Comment, DbObjectId, Guid, DtoId)
+    VALUES (@ParentEntityId, @PropertyType, @TypeFullName, @Name, @HasSetter, @HasGetter, @IsList, @IsNullable, @Comment, @DbObjectId, @Guid, @DtoId);";
+
+            var wasClosed = this._connection.State != System.Data.ConnectionState.Open;
+            if (wasClosed)
+            {
+                await this._connection.OpenAsync(ct);
+            }
+
+            using var trans = this._connection.BeginTransaction();
+            try
+            {
+                await this._connection.ExecuteAsync(dtoSql, new
+                {
+                    dto.Name,
+                    NameSpace = dto.Namespace,
+                    dto.ModuleId,
+                    dto.DbObjectId,
+                    dto.Guid,
+                    dto.Comment,
+                    dto.IsParamsDto,
+                    dto.IsResultDto,
+                    dto.IsViewModel,
+                    dto.IsList,
+                    dto.BaseType,
+                    Id = id
+                }, trans);
+
+                await this._connection.ExecuteAsync(deletePropSql, new { Id = id }, trans);
+
+                foreach (var prop in dto.Properties)
+                {
+                    await this._connection.ExecuteAsync(propSql, new
+                    {
+                        ParentEntityId = id,
+                        prop.PropertyType,
+                        prop.TypeFullName,
+                        prop.Name,
+                        prop.HasSetter,
+                        prop.HasGetter,
+                        prop.IsList,
+                        prop.IsNullable,
+                        prop.Comment,
+                        prop.DbObjectId,
+                        prop.Guid,
+                        DtoId = id
+                    }, trans);
+                }
+
+                trans.Commit();
+                if (wasClosed)
+                {
+                    await this._connection.CloseAsync();
+                }
+            }
+            catch
+            {
+                trans.Rollback();
+                if (wasClosed)
+                {
+                    await this._connection.CloseAsync();
+                }
+                throw;
+            }
+        });
 }

--- a/src/infra/CodeGenerator/Application/Services/ModuleService.cs
+++ b/src/infra/CodeGenerator/Application/Services/ModuleService.cs
@@ -11,7 +11,6 @@ using Library.Resulting;
 
 using Microsoft.Data.SqlClient;
 
-using Action = Library.Extensions.DelegateExtension;
 
 namespace CodeGenerator.Application.Services;
 
@@ -19,9 +18,9 @@ internal sealed class ModuleService(SqlConnection connection) : IModuleService
 {
     [return: NotNull]
     public Task<IResult<IEnumerable<Module>>> GetAll(CancellationToken ct = default) =>
-        Action.ToResult(() => connection.QueryAsync<Module>("SELECT * FROM [infra].[Module]"));
+        CatchResultAsync(() => connection.QueryAsync<Module>("SELECT * FROM [infra].[Module]"));
 
     [return: NotNull]
     public Task<IResult<Module?>> GetById(long id, CancellationToken ct = default) =>
-        Action.ToResult(() => connection.QueryFirstOrDefaultAsync<Module>("SELECT * FROM [infra].[Module] WHERE Id = @Id", new { Id = id }));
+        CatchResultAsync(() => connection.QueryFirstOrDefaultAsync<Module>("SELECT * FROM [infra].[Module] WHERE Id = @Id", new { Id = id }));
 }


### PR DESCRIPTION
## Summary
- update DtoService and ModuleService to use `CatchResultAsync`
- clean up unused `Action.ToResult` alias

## Testing
- `dotnet build src/infra/CodeGenerator/CodeGenerator.csproj -v q` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688520841bf883269d6a44f8284d612e