### PR TITLE
Load DTO list on page initialization

### DIFF
--- a/src/infra/CodeGenerator/Application/Domain/Extensions.cs
+++ b/src/infra/CodeGenerator/Application/Domain/Extensions.cs
@@ -37,4 +37,21 @@ internal static class Extensions
         var value = await task;
         return value.ToViewModel();
     }
+
+    [return: NotNullIfNotNull(nameof(model))]
+    public static DtoViewModel ToViewModel(this Dto model) => new()
+    {
+        Id = model.Id,
+        Name = model.Name,
+    };
+
+    [return: NotNull]
+    public static IEnumerable<DtoViewModel> ToViewModel([AllowNull] this IEnumerable<Dto> models)
+        => models?.Select(ToViewModel) ?? [];
+
+    public static async Task<IEnumerable<DtoViewModel>> ToViewModel(this Task<IEnumerable<Dto>> task)
+    {
+        var value = await task;
+        return value.ToViewModel();
+    }
 }

--- a/src/infra/CodeGenerator/Designer/UI/Pages/DtoManagementPage.xaml
+++ b/src/infra/CodeGenerator/Designer/UI/Pages/DtoManagementPage.xaml
@@ -37,7 +37,10 @@
             </ToolBar>
         </bases:BasePage.ToolbarContent>
         <bases:BasePage.SidebarContent>
-            <ListBox />
+            <ListBox
+                ItemsSource="{Binding ElementName=Me, Path=StaticViewModel.Dtos}"
+                DisplayMemberPath="Name"
+                SelectedValuePath="Id" />
         </bases:BasePage.SidebarContent>
         <bases:BasePage.EntityDesignerContent>
             <Grid x:Name="EntityDesignerGrid">

--- a/src/infra/CodeGenerator/Designer/UI/Pages/DtoManagementPage.xaml.cs
+++ b/src/infra/CodeGenerator/Designer/UI/Pages/DtoManagementPage.xaml.cs
@@ -85,7 +85,8 @@ public partial class DtoManagementPage : UserControl
     {
         var modules = await this._moduleService.GetAll().ParseValue().ToViewModel();
         var dataTypes = SqlType.GetSqlTypes().Select(x => x.SqlType.SqlTypeName);
-        this.StaticViewModel = new(modules, dataTypes);
+        var dtos = await this._dtoService.GetAll().ParseValue().ToViewModel();
+        this.StaticViewModel = new(modules, dataTypes, dtos);
     }
 
     private void NewDtoButton_Click(object sender, RoutedEventArgs e)
@@ -166,8 +167,12 @@ public partial class DtoManagementPage : UserControl
     }
 }
 
-public sealed partial class DtoManagementPageStaticViewModel(IEnumerable<ModuleViewModel> modules, IEnumerable<string> dataTypes)
+public sealed partial class DtoManagementPageStaticViewModel(
+    IEnumerable<ModuleViewModel> modules,
+    IEnumerable<string> dataTypes,
+    IEnumerable<DtoViewModel> dtos)
 {
     public ObservableCollection<string> DataTypes { get; } = new(dataTypes);
     public ObservableCollection<ModuleViewModel> Modules { get; } = new(modules);
+    public ObservableCollection<DtoViewModel> Dtos { get; } = new(dtos);
 }


### PR DESCRIPTION
## Summary
- [CodeGenerator] در زمان بارگذاری `DtoManagementPage`، DTOهای موجود از دیتابیس دریافت شده و در ListBox نمایش داده می‌شوند
- افزودن `Dtos` به ViewModel ثابت صفحه برای نگه‌داری لیست DTO ها
- اضافه شدن متدهای تبدیل `Dto` به `DtoViewModel`

## Testing
- `dotnet build src/infra/CodeGenerator/CodeGenerator.csproj -c Release` *(شکست به‌دلیل نبود SDK .NET 10)*

------
https://chatgpt.com/codex/tasks/task_e_688cfb24d24c83269f8c1c042bf0aae0