### PR TITLE
[CodeGenerator] غیرفعال‌سازی کنترل‌ها هنگام نبود DataContext

### DIFF
--- a/src/infra/CodeGenerator/Designer/UI/Pages/DtoManagementPage.xaml.cs
+++ b/src/infra/CodeGenerator/Designer/UI/Pages/DtoManagementPage.xaml.cs
@@ -35,6 +35,7 @@ public partial class DtoManagementPage : UserControl
 
         this.DataContextChanged += this.DtoManagementPage_DataContextChanged;
         this.Loaded += this.DtoManagementPage_Loaded;
+        this.UpdateUiEnabledState();
     }
 
     public DtoManagementPageStaticViewModel StaticViewModel
@@ -44,7 +45,14 @@ public partial class DtoManagementPage : UserControl
     }
 
     private void DtoManagementPage_DataContextChanged(object sender, DependencyPropertyChangedEventArgs e) =>
-        this.EntityDesignerGrid.IsEnabled = e.NewValue is not null;
+        this.UpdateUiEnabledState();
+
+    private void UpdateUiEnabledState()
+    {
+        var isEnabled = this.DataContext is not null;
+        this.EntityDesignerGrid.IsEnabled = isEnabled;
+        this.CodesViewer.IsEnabled = isEnabled;
+    }
 
     private async void DtoManagementPage_Loaded(object sender, RoutedEventArgs e)
     {


### PR DESCRIPTION
## خلاصه
- کنترل‌های EntityDesignerGrid و CodesViewer در نبود DataContext غیر‌فعال می‌شوند

## تست‌ها
- `dotnet build MES20.slnx` *(شکست به‌دلیل ناسازگاری نسخه SDK با فرمت slnx)*

------
https://chatgpt.com/codex/tasks/task_e_68a0d8ede5f08326a28c5c2f44fa72b4